### PR TITLE
make fcs.py executable

### DIFF
--- a/fcs.py
+++ b/fcs.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python3
 from modules.runtime.main import main
 
 if __name__ == "__main__":


### PR DESCRIPTION
Adding the file header so we can run the file directly without using the python3 command as prefix